### PR TITLE
Add support for non-binding variables on generated components

### DIFF
--- a/Output/CollectionViewComponent.generated.swift
+++ b/Output/CollectionViewComponent.generated.swift
@@ -84,4 +84,5 @@ struct EditorialViewModel: Hashable {
   let image: UIImage?
   let title: String
   let subtitle: String
+  let navigation: URL
 }

--- a/Output/CollectionViewItemComponent.generated.swift
+++ b/Output/CollectionViewItemComponent.generated.swift
@@ -89,4 +89,5 @@ struct EditorialMacOSViewModel: Hashable {
   let image: NSImage
   let title: String
   let subtitle: String
+  let navigation: URL
 }

--- a/Output/TableViewComponent.generated.swift
+++ b/Output/TableViewComponent.generated.swift
@@ -83,4 +83,5 @@ struct EditorialTableViewCellModel: Hashable {
   let image: UIImage?
   let title: String
   let subtitle: String
+  let navigation: URL
 }

--- a/Samples/iOS+tvOS/EditorialTableViewCell.swift
+++ b/Samples/iOS+tvOS/EditorialTableViewCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+// sourcery: navigation = "URL"
 class EditorialTableViewCell: UITableViewCell, TableViewComponent, StatefulView {
   // sourcery: image: UIImage? = "posterView.image = model.image"
   lazy var posterView = UIImageView()

--- a/Samples/iOS+tvOS/EditorialView.swift
+++ b/Samples/iOS+tvOS/EditorialView.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+// sourcery: navigation = "URL"
 class EditorialView: UICollectionViewCell, CollectionViewComponent, StatefulView {
   // sourcery: image: UIImage? = "imageView.image = model.image"
   lazy var imageView = UIImageView()

--- a/Samples/macOS/EditorialMacOSView.swift
+++ b/Samples/macOS/EditorialMacOSView.swift
@@ -1,5 +1,6 @@
 import Cocoa
- 
+
+ // sourcery: navigation = "URL"
 class EditorialMacOSView: NSCollectionViewItem, CollectionViewItemComponent {
   // sourcery: image: NSImage = "customImageView.image = model.image"
   lazy var customImageView = NSImageView()

--- a/Templates/iOS+tvOS/CollectionViewComponent.stencil
+++ b/Templates/iOS+tvOS/CollectionViewComponent.stencil
@@ -94,5 +94,8 @@ struct {{type.name}}Model: Hashable {
     {% endfor %}
   {% endfor %}
   {% endfor %}
+  {% for key in type.annotations %}
+  let {{key}}: {{type.annotations[key]}}
+  {% endfor %}
 }
 {% endfor %}

--- a/Templates/iOS+tvOS/TableViewComponent.stencil
+++ b/Templates/iOS+tvOS/TableViewComponent.stencil
@@ -93,5 +93,8 @@ struct {{type.name}}Model: Hashable {
     {% endfor %}
   {% endfor %}
   {% endfor %}
+  {% for key in type.annotations %}
+  let {{key}}: {{type.annotations[key]}}
+  {% endfor %}
 }
 {% endfor %}

--- a/Templates/macOS/CollectionViewItemComponent.stencil
+++ b/Templates/macOS/CollectionViewItemComponent.stencil
@@ -95,5 +95,8 @@ struct {{type.name}}Model: Hashable {
     {% endfor %}
   {% endfor %}
   {% endfor %}
+  {% for key in type.annotations %}
+  let {{key}}: {{type.annotations[key]}}
+  {% endfor %}
 }
 {% endfor %}


### PR DESCRIPTION
This PR adds support for non-binding variables on generated models.
If you annotate the class type, you can add variables that don't get aggregated on the view, such as navigation.

## Example

### EditorialView.swift
```swift
// sourcery: navigation = "URL"
class EditorialView: UICollectionViewCell, CollectionViewComponent, StatefulView {
  // sourcery: image: UIImage? = "imageView.image = model.image"
  lazy var imageView = UIImageView()
  // sourcery: title: String = "titleLabel.text = model.title"
  lazy var titleLabel = UILabel()
  // sourcery: subtitle: String = "subtitleLabel.text = model.subtitle"
  lazy var subtitleLabel = UILabel()
}
```

### Output
```swift
struct EditorialViewModel: Hashable {
  let image: UIImage?
  let title: String
  let subtitle: String
  let navigation: URL
}
```