### PR TITLE
Improve view model mapping and add constraints to ViewControllerFactory

### DIFF
--- a/Output/CollectionViewComponent.generated.swift
+++ b/Output/CollectionViewComponent.generated.swift
@@ -34,8 +34,14 @@ class EditorialViewController: UIViewController {
     collectionView.register(EditorialView.self, forCellWithReuseIdentifier: "EditorialView")
   }
 
-  func reload(with models: [EditorialViewModel]) {
-    dataSource.reload(collectionView, with: models)
+  // MARK: - Public API
+
+  func model(at indexPath: IndexPath) -> EditorialViewModel {
+    return dataSource.model(at: indexPath)
+  }
+
+  func reload(with models: [EditorialViewModel], completion: (() -> Void)? = nil) {
+    dataSource.reload(collectionView, with: models, then: completion)
   }
 }
 
@@ -55,9 +61,11 @@ class EditorialDataSource: NSObject, UICollectionViewDataSource {
   }
 
   func reload(_ collectionView: UICollectionView,
-              with models: [EditorialViewModel]) {
+              with models: [EditorialViewModel],
+              then handler: (() -> Void)? = nil) {
     self.models = models
     collectionView.reloadData()
+    handler?()
   }
 
   // MARK: - UICollectionViewDataSource

--- a/Output/CollectionViewItemComponent-macOS.generated.swift
+++ b/Output/CollectionViewItemComponent-macOS.generated.swift
@@ -38,8 +38,12 @@ class EditorialItemViewController: NSViewController {
 
   // MARK: - Public API
 
-  func reload(with models: [EditorialItemModel]) {
-    dataSource.reload(collectionView, with: models)
+  func model(at indexPath: IndexPath) -> EditorialItemModel {
+    return dataSource.model(at: indexPath)
+  }
+
+  func reload(with models: [EditorialItemModel], completion: (() -> Void)? = nil) {
+    dataSource.reload(collectionView, with: models, then: completion)
   }
 }
 
@@ -59,9 +63,11 @@ class EditorialItemDataSource: NSObject, NSCollectionViewDataSource {
   }
 
   func reload(_ collectionView: NSCollectionView,
-              with models: [EditorialItemModel]) {
+              with models: [EditorialItemModel],
+              then handler: (() -> Void)? = nil) {
     self.models = models
     collectionView.reloadData()
+    handler?()
   }
 
   // MARK: - NSCollectionViewDataSource
@@ -76,9 +82,9 @@ class EditorialItemDataSource: NSObject, NSCollectionViewDataSource {
     let model = self.model(at: indexPath)
 
     if let view = item as? EditorialItem {
-      view.customImageView.image = model.image
-      view.titleLabel.stringValue = model.title
-      view.subtitleLabel.stringValue = model.subtitle
+          view.customImageView.image = model.image
+          view.titleLabel.stringValue = model.title
+          view.subtitleLabel.stringValue = model.subtitle
     }
 
     return item

--- a/Output/ViewControllerFactory.generated.swift
+++ b/Output/ViewControllerFactory.generated.swift
@@ -17,12 +17,10 @@ class ViewControllerFactory {
 
     return stateController
   }
-
   public func createEditorialTableViewController() -> EditorialTableViewController {
     let viewController = EditorialTableViewController()
     return viewController
   }
-
   public func createEditorialViewStateController(layout: UICollectionViewFlowLayout,
                                           initialViewController: UIViewController = .init(),
                                           loadingViewController: UIViewController = .init(),

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ The idea is to have your views conform to a protocol called `CollectionViewCompo
 import UIKit
 
 class EditorialView: UICollectionViewCell, CollectionViewComponent {
-  // sourcery: image: UIImage? = "imageView.image = model.image"
+  // sourcery: let image: UIImage? = "imageView.image = model.image"
   lazy var imageView = UIImageView()
-  // sourcery: title: String = "titleLabel.text = model.title"
+  // sourcery: let title: String = "titleLabel.text = model.title"
   lazy var titleLabel = UILabel()
-  // sourcery: subtitle: String = "subtitleLabel.text = model.subtitle"
+  // sourcery: let subtitle: String = "subtitleLabel.text = model.subtitle"
   lazy var subtitleLabel = UILabel()
 }
 ```
@@ -74,7 +74,7 @@ struct EditorialViewModel: Hashable {
 If we take a closer look at the annotations:
 
 ```
-// sourcery: image: UIImage? = "imageView.image = model.image"
+// sourcery: let image: UIImage? = "imageView.image = model.image"
 ```
 
 The first part which acts as the key for the annotation is used to create the model property.

--- a/Samples/iOS+tvOS/EditorialTableViewCell.swift
+++ b/Samples/iOS+tvOS/EditorialTableViewCell.swift
@@ -1,11 +1,11 @@
 import UIKit
 
-// sourcery: navigation = "URL"
+// sourcery: let navigation = "URL"
 class EditorialTableViewCell: UITableViewCell, TableViewComponent, StatefulView {
-  // sourcery: image: UIImage? = "posterView.image = model.image"
+  // sourcery: let image: UIImage? = "posterView.image = model.image"
   lazy var posterView = UIImageView()
-  // sourcery: title: String = "titleLabel.text = model.title"
+  // sourcery: let title: String = "titleLabel.text = model.title"
   lazy var titleLabel = UILabel()
-  // sourcery: subtitle: String = "subtitleLabel.text = model.subtitle"
+  // sourcery: let subtitle: String = "subtitleLabel.text = model.subtitle"
   lazy var subtitleLabel = UILabel()
 }

--- a/Samples/iOS+tvOS/EditorialView.swift
+++ b/Samples/iOS+tvOS/EditorialView.swift
@@ -1,11 +1,11 @@
 import UIKit
 
-// sourcery: navigation = "URL"
+// sourcery: let navigation = "URL"
 class EditorialView: UICollectionViewCell, CollectionViewComponent, StatefulView {
-  // sourcery: image: UIImage? = "imageView.image = model.image"
+  // sourcery: let image: UIImage? = "imageView.image = model.image"
   lazy var imageView = UIImageView()
-  // sourcery: title: String = "titleLabel.text = model.title"
+  // sourcery: let title: String = "titleLabel.text = model.title"
   lazy var titleLabel = UILabel()
-  // sourcery: subtitle: String = "subtitleLabel.text = model.subtitle"
+  // sourcery: let subtitle: String = "subtitleLabel.text = model.subtitle"
   lazy var subtitleLabel = UILabel()
 }

--- a/Samples/macOS/EditorialMacOSView.swift
+++ b/Samples/macOS/EditorialMacOSView.swift
@@ -1,12 +1,12 @@
 import Cocoa
 
- // sourcery: navigation = "URL"
+ // sourcery: let navigation = "URL"
 class EditorialItem: NSCollectionViewItem, CollectionViewItemComponent, StatefulItem {
-  // sourcery: image: NSImage = "customImageView.image = model.image"
+  // sourcery: let image: NSImage = "customImageView.image = model.image"
   lazy var customImageView = NSImageView()
-  // sourcery: title: String = "titleLabel.stringValue = model.title"
+  // sourcery: let title: String = "titleLabel.stringValue = model.title"
   lazy var titleLabel = NSTextField()
-  // sourcery: subtitle: String = "subtitleLabel.stringValue = model.subtitle"
+  // sourcery: let subtitle: String = "subtitleLabel.stringValue = model.subtitle"
   lazy var subtitleLabel = NSTextField()
 
   private var layoutConstraints = [NSLayoutConstraint]()

--- a/Templates/iOS+tvOS/CollectionViewComponent.stencil
+++ b/Templates/iOS+tvOS/CollectionViewComponent.stencil
@@ -32,8 +32,14 @@ class {{type.name}}Controller: UIViewController {
     collectionView.register({{type.name}}.self, forCellWithReuseIdentifier: "{{type.name}}")
   }
 
-  func reload(with models: [{{type.name}}Model]) {
-    dataSource.reload(collectionView, with: models)
+  // MARK: - Public API
+
+  func model(at indexPath: IndexPath) -> {{type.name}}Model {
+    return dataSource.model(at: indexPath)
+  }
+
+  func reload(with models: [{{type.name}}Model], completion: (() -> Void)? = nil) {
+    dataSource.reload(collectionView, with: models, then: completion)
   }
 }
 
@@ -53,9 +59,11 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, UICollectionViewDataS
   }
 
   func reload(_ collectionView: UICollectionView,
-              with models: [{{type.name}}Model]) {
+              with models: [{{type.name}}Model],
+              then handler: (() -> Void)? = nil) {
     self.models = models
     collectionView.reloadData()
+    handler?()
   }
 
   // MARK: - UICollectionViewDataSource
@@ -70,12 +78,14 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, UICollectionViewDataS
 
     if let view = cell as? {{type.name}} {
       {% for variable in type.variables %}
-      {% for key in variable.annotations %}
-        {% for variableType in variable.annotations[key] %}
-          {% if forloop.last %}
+      {% for key, value in variable.annotations %}
+        {% if value.length > 0 %}
+      view.{{key}} = {{value}}
+        {% else %}
+          {% for variableType in value %}
       view.{{variable.annotations[key][variableType]}}
-          {% endif %}
         {% endfor %}
+        {% endif %}
       {% endfor %}
       {% endfor %}
     }
@@ -86,16 +96,14 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, UICollectionViewDataS
 
 struct {{type.name}}Model: Hashable {
   {% for variable in type.variables %}
-  {% for key in variable.annotations %}
+  {% for key, value in variable.annotations %}
     {% for variableType in variable.annotations[key] %}
-    {% if forloop.last %}
-  let {{key}}: {{variableType}}
-    {% endif %}
+  {{key}}: {{variableType}}
     {% endfor %}
   {% endfor %}
   {% endfor %}
   {% for key in type.annotations %}
-  let {{key}}: {{type.annotations[key]}}
+  {{key}}: {{type.annotations[key]}}
   {% endfor %}
 }
 {% endfor %}

--- a/Templates/iOS+tvOS/TableViewComponent.stencil
+++ b/Templates/iOS+tvOS/TableViewComponent.stencil
@@ -69,12 +69,14 @@ class {{type.name|replace:"Cell",""}}DataSource: NSObject, UITableViewDataSource
 
     if let view = cell as? {{type.name}} {
       {% for variable in type.variables %}
-      {% for key in variable.annotations %}
-        {% for variableType in variable.annotations[key] %}
-          {% if forloop.last %}
+      {% for key, value in variable.annotations %}
+        {% if value.length > 0 %}
+      view.{{key}} = {{value}}
+        {% else %}
+          {% for variableType in value %}
       view.{{variable.annotations[key][variableType]}}
-          {% endif %}
         {% endfor %}
+        {% endif %}
       {% endfor %}
       {% endfor %}
     }
@@ -85,16 +87,14 @@ class {{type.name|replace:"Cell",""}}DataSource: NSObject, UITableViewDataSource
 
 struct {{type.name}}Model: Hashable {
   {% for variable in type.variables %}
-  {% for key in variable.annotations %}
+  {% for key, value in variable.annotations %}
     {% for variableType in variable.annotations[key] %}
-    {% if forloop.last %}
-  let {{key}}: {{variableType}}
-    {% endif %}
+  {{key}}: {{variableType}}
     {% endfor %}
   {% endfor %}
   {% endfor %}
   {% for key in type.annotations %}
-  let {{key}}: {{type.annotations[key]}}
+  {{key}}: {{type.annotations[key]}}
   {% endfor %}
 }
 {% endfor %}

--- a/Templates/iOS+tvOS/ViewControllerFactory.stencil
+++ b/Templates/iOS+tvOS/ViewControllerFactory.stencil
@@ -2,6 +2,7 @@ import UIKit
 
 class ViewControllerFactory {
   {% for type in types.implementing.TableViewComponent %}
+  {% if type.implements.StatefulView %}
   public func create{{type.name|replace:"Cell",""}}StateController(initialViewController: UIViewController = .init(),
                                           loadingViewController: UIViewController = .init(),
                                           failureViewController: {{type.name}}StateController.ErrorViewControllerType) -> {{type.name}}StateController {
@@ -15,14 +16,14 @@ class ViewControllerFactory {
 
     return stateController
   }
-
+  {% endif %}
   public func create{{type.name|replace:"View",""|replace:"Cell",""}}ViewController() -> {{type.name|replace:"View",""|replace:"Cell",""}}ViewController {
     let viewController = {{type.name|replace:"View",""|replace:"Cell",""}}ViewController()
     return viewController
   }
   {% endfor %}
-
   {% for type in types.implementing.CollectionViewComponent %}
+  {% if type.implements.StatefulView %}
   public func create{{type.name}}StateController(layout: UICollectionViewFlowLayout,
                                           initialViewController: UIViewController = .init(),
                                           loadingViewController: UIViewController = .init(),
@@ -37,6 +38,7 @@ class ViewControllerFactory {
 
     return stateController
   }
+  {% endif %}
 
   public func create{{type.name|replace:"View",""}}ViewController(layout: UICollectionViewFlowLayout) -> {{type.name|replace:"View",""}}ViewController {
     let viewController = {{type.name|replace:"View",""}}ViewController(layout: layout)

--- a/Templates/macOS/CollectionViewItemComponent-macOS.stencil
+++ b/Templates/macOS/CollectionViewItemComponent-macOS.stencil
@@ -36,8 +36,12 @@ class {{type.name|replace:"View",""}}ViewController: NSViewController {
 
   // MARK: - Public API
 
-  func reload(with models: [{{type.name}}Model]) {
-    dataSource.reload(collectionView, with: models)
+  func model(at indexPath: IndexPath) -> {{type.name}}Model {
+    return dataSource.model(at: indexPath)
+  }
+
+  func reload(with models: [{{type.name}}Model], completion: (() -> Void)? = nil) {
+    dataSource.reload(collectionView, with: models, then: completion)
   }
 }
 
@@ -57,9 +61,11 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, NSCollectionViewDataS
   }
 
   func reload(_ collectionView: NSCollectionView,
-              with models: [{{type.name}}Model]) {
+              with models: [{{type.name}}Model],
+              then handler: (() -> Void)? = nil) {
     self.models = models
     collectionView.reloadData()
+    handler?()
   }
 
   // MARK: - NSCollectionViewDataSource
@@ -75,10 +81,14 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, NSCollectionViewDataS
 
     if let view = item as? {{type.name}} {
       {% for variable in type.variables %}
-      {% for key in variable.annotations %}
-        {% for variableType in variable.annotations[key] %}
-      view.{{variable.annotations[key][variableType]}}
+      {% for key, value in variable.annotations %}
+        {% if value.length > 0 %}
+          view.{{key}} = {{value}}
+        {% else %}
+          {% for variableType in value %}
+          view.{{variable.annotations[key][variableType]}}
         {% endfor %}
+        {% endif %}
       {% endfor %}
       {% endfor %}
     }
@@ -89,14 +99,14 @@ class {{type.name|replace:"View",""}}DataSource: NSObject, NSCollectionViewDataS
 
 struct {{type.name}}Model: Hashable {
   {% for variable in type.variables %}
-  {% for key in variable.annotations %}
+  {% for key, value in variable.annotations %}
     {% for variableType in variable.annotations[key] %}
-  let {{key}}: {{variableType}}
+  {{key}}: {{variableType}}
     {% endfor %}
   {% endfor %}
   {% endfor %}
   {% for key in type.annotations %}
-  let {{key}}: {{type.annotations[key]}}
+  {{key}}: {{type.annotations[key]}}
   {% endfor %}
 }
 {% endfor %}


### PR DESCRIPTION
- View model bindings now require `let` or`var`.
- View model bindings now support bindings without using model entities.
- View controller factory will no longer generate all state controller without the views conforming to `StatefulView`
- Reload on `Component` has been given a completion.
- `Component` has a new method for getting the model at a specific index path.

I learned a bunch about the templates when implementing support for `Voodoo` in [Gray](https://github.com/zenangst/Gray). I thought it would be a good idea to include them in the core templates going further. I think the biggest thing is the model bindings, it now supports a bunch of nifty new things and gives you more control as you define `var` and `let` in your annotations. Even if `let` should be the go-to, but you never know. Also, having `let` be hard-coded in the template never felt like a good idea in the first place.